### PR TITLE
support relu layer

### DIFF
--- a/src/kerassurgeon/surgeon.py
+++ b/src/kerassurgeon/surgeon.py
@@ -505,7 +505,8 @@ class Surgeon:
                              'ThresholdedReLU',
                              'GaussianNoise',
                              'GaussianDropout',
-                             'AlphaDropout'):
+                             'AlphaDropout',
+                             'ReLU'):
             # Pass-through layers
             outbound_mask = inbound_masks
             new_layer = layer

--- a/tests/test_surgeon.py
+++ b/tests/test_surgeon.py
@@ -17,6 +17,8 @@ from tensorflow.keras.layers import Add, Multiply, Average, Maximum, Concatenate
 from tensorflow.keras.layers import LeakyReLU, ELU, ThresholdedReLU
 from tensorflow.keras.layers import GaussianNoise, GaussianDropout, AlphaDropout
 from tensorflow.keras.layers import SimpleRNN, GRU, LSTM, BatchNormalization
+from tensorflow.keras.layers import ReLU
+
 from numpy import random
 
 from kerassurgeon import operations
@@ -388,6 +390,7 @@ def test_delete_channels_advanced_activations(channel_index, data_format):
     layer_test_helper_flatten_2d(LeakyReLU(), channel_index, data_format)
     layer_test_helper_flatten_2d(ELU(), channel_index, data_format)
     layer_test_helper_flatten_2d(ThresholdedReLU(), channel_index, data_format)
+    layer_test_helper_flatten_2d(ReLU(), channel_index, data_format)
 
 
 def test_delete_channels_noise(channel_index, data_format):


### PR DESCRIPTION
Supports ReLU layers by simply "white listing" them and treating them like other layers that just pass on the same shape like, e.g. LeakyReLU or Activation.