### PR TITLE
TF 2.4 raises a val err: Keras symbolic inputs/outputs do not impleme…

### DIFF
--- a/src/kerassurgeon/utils.py
+++ b/src/kerassurgeon/utils.py
@@ -2,6 +2,7 @@
 import numpy as np
 from tensorflow.keras.layers import Layer
 from tensorflow.keras.activations import linear
+from tensorflow.python.keras.engine import keras_tensor
 import tensorflow as tf
 from ._utils import node as node_utils
 
@@ -137,20 +138,30 @@ def sort_x_by_y(x, y):
 
 def single_element(x):
     """If x contains a single element, return it; otherwise return x"""
-    if isinstance(x, tf.Tensor):
+
+    if isinstance(x, (tf.Tensor, keras_tensor.KerasTensor)): 
         return x
 
-    if len(x) == 1:
-        x = x[0]
+    if isinstance(x, list):
+        if len(x) == 1:
+            return x[0]
+
+    if isinstance(x, tuple):
+        return x[0]
+
     return x
 
 
 def get_one_tensor(x):
-    if isinstance(x, tf.Tensor):
+
+    if isinstance(x, (tf.Tensor, keras_tensor.KerasTensor)): 
         return x
 
-    assert len(x) == 1
-    return x[0]
+    if isinstance(x, list):
+        if len(x) == 1:
+            return x[0]
+
+    return x
 
 
 def bool_to_index(x):


### PR DESCRIPTION
When running inside of tensorflow 2.4, I am getting the following error: `TypeError: Keras symbolic inputs/outputs do not implement __len__. You may be trying to pass Keras symbolic inputs/outputs to a TF API that does not register dispatching, preventing Keras from automatically converting the API call to a lambda layer in the Functional Model. This error will also get raised if you try asserting a symbolic input/output directly.` 

This is due to the fact that `utils.py` checks for the length of the input tensors... the fix is to check if we have a single tensor instance, a tuple, or a list. Here we assume that we have a single tensor anyways and as far as I know there is no support for multiple outputs.