### PR TITLE
Add CI using Github Action to run tox

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,8 @@ on:
   push:
     branches: [master]
   pull_request:
-
+  # Allow manual runs of the Github Action
+  workflow_dispatch:
 
 name: Continuous integration
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+
+name: Continuous integration
+
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.6
+      - name: Install package locally
+        run: poetry install
+      - name: Check locally-built package is ready
+        run: pip show keras-surgeon
+      # Disabled while we check the basics of package install
+      # - name: Run tox
+      #   run: tox
+

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         python-version: [3.6]
         os: [ubuntu-18.04, macos-latest, windows-latest]
+        tf2_version: [0,1,2,3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -23,11 +24,9 @@ jobs:
       - uses: abatilo/actions-poetry@v2.0.0
         with:
           poetry-version: 1.1.6
-      - name: Install package locally
-        run: poetry install
-      - name: Check locally-built package is ready
-        run: pip show keras-surgeon
-      # Disabled while we check the basics of package install
-      # - name: Run tox
-      #   run: tox
 
+      - name: Install deps and package
+        run: poetry install
+
+      - name: Run tox
+        run: tox -e py36-tf2_${{ matrix.tf2_version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6]
         os: [ubuntu-18.04, macos-latest, windows-latest]
-        tf2_version: [0,1,2,3]
+        python-version: [3.6]
+        tf2_version: [tf2_0, tf2_1, tf2_2, tf2_3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -29,4 +29,4 @@ jobs:
         run: poetry install
 
       - name: Run tox
-        run: poetry run tox -e py36-tf2_${{ matrix.tf2_version }}
+        run: poetry run tox -e py36-${{ matrix.tf2_version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,4 +29,4 @@ jobs:
         run: poetry install
 
       - name: Run tox
-        run: tox -e py36-tf2_${{ matrix.tf2_version }}
+        run: poetry run tox -e py36-tf2_${{ matrix.tf2_version }}


### PR DESCRIPTION
Installs package from poetry, then runs tox in multiple envs.
Sadly kind of reimplements the tox matrix.

Only pushes to master & PRs trigger job (not branches), with a manual trigger possible.