### PR TITLE
TypeError: 'NoneType' object is not subscriptable

### DIFF
--- a/src/kerassurgeon/surgeon.py
+++ b/src/kerassurgeon/surgeon.py
@@ -441,7 +441,7 @@ class Surgeon:
                              'MaxPooling3D',
                              'AveragePooling1D', 'AveragePooling2D',
                              'AveragePooling3D'):
-            index = [slice(None, x, None) for x in output_shape[1:]]
+            index = [slice(None, x, None) for x in layer.output_shape[1:]]
             if data_format == 'channels_first':
                 index[0] = slice(None)
             elif data_format == 'channels_last':


### PR DESCRIPTION
This Typo on getting layer output shape is generating the folowing error :
```
Traceback (most recent call last):
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 234, in _rebuild_rec
    output_mask = mask_map[node_output]
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\_utils\tensor_dict.py", line 25, in __getitem__
    return super().__getitem__(item.ref())
KeyError: <Reference wrapping <KerasTensor: shape=(None, 10) dtype=float32 (created by layer 'dense')>>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 234, in _rebuild_rec
    output_mask = mask_map[node_output]
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\_utils\tensor_dict.py", line 25, in __getitem__
    return super().__getitem__(item.ref())
KeyError: <Reference wrapping <KerasTensor: shape=(None, 2028) dtype=float32 (created by layer 'flatten')>>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 234, in _rebuild_rec
    output_mask = mask_map[node_output]
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\_utils\tensor_dict.py", line 25, in __getitem__
    return super().__getitem__(item.ref())
KeyError: <Reference wrapping <KerasTensor: shape=(None, 13, 13, 12) dtype=float32 (created by layer 'max_pooling2d')>>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:/Users/arthur/source/repos/pruning/main.py", line 86, in <module>
    perc=0.2)
  File "C:\Users\arthur\source\repos\pruning\pruning.py", line 131, in prune_model
    model_pruned = prune_multiple_layers(model, to_prune, opt)
  File "C:\Users\arthur\source\repos\pruning\pruning.py", line 97, in prune_multiple_layers
    model_pruned = surgeon.operate()
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 166, in operate
    new_outputs, _ = self._rebuild_graph(self.model.inputs, output_nodes)
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 278, in _rebuild_graph
    outputs, output_masks = zip(*[_rebuild_rec(n) for n in output_nodes])
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 278, in <listcomp>
    outputs, output_masks = zip(*[_rebuild_rec(n) for n in output_nodes])
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 245, in _rebuild_rec
    *[_rebuild_rec(n) for n in inbound_nodes])
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 245, in <listcomp>
    *[_rebuild_rec(n) for n in inbound_nodes])
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 245, in _rebuild_rec
    *[_rebuild_rec(n) for n in inbound_nodes])
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 245, in <listcomp>
    *[_rebuild_rec(n) for n in inbound_nodes])
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 268, in _rebuild_rec
    new_layer, output_mask = self._apply_delete_mask(node, input_masks)
  File "C:\Users\arthur\.virtualenvs\pruning\lib\site-packages\kerassurgeon\surgeon.py", line 444, in _apply_delete_mask
    index = [slice(None, x, None) for x in output_shape[1:]]
TypeError: 'NoneType' object is not subscriptable
Process finished with exit code 1
```

While debugging i found out it was just a typing mistake :
Instead of :
```index = [slice(None, x, None) for x in output_shape[1:]]```
Needs to be :
```index = [slice(None, x, None) for x in layer.output_shape[1:]]```